### PR TITLE
updated launch function to include all apps on the system

### DIFF
--- a/.config/zsh/.zfunctions
+++ b/.config/zsh/.zfunctions
@@ -42,7 +42,7 @@ function fkill() {
 
 # macOS fuzzy app launcher
 function launch() {
-	open -a "`find /Applications -name '*app' -maxdepth 1 | cut -d'/' -f 3 | cut -d'.' -f 1 | fzf --query=$1`"
+	open -a "$(find /Applications /System/Applications/ /System/Applications/Utilities -name '*app' -maxdepth 1 -exec basename {} .app \; | fzf --query "$1")"
 }
 
 # END fzf integrations }}}


### PR DESCRIPTION
Hey!

I read your blog post on [Launching Apps From The macOS Terminal](https://alichtman.com/blog/launching-apps-macos-terminal/) and I found it very interesting. 

The function you created is really creative. I tried it on my mac and I noticed that apps such as Disk Utility and the Terminal.app were not showing up. I took a further look at your function and noticed how it is only searching in the `/Applications` directory. After finding the actual paths of some of the system apps (macOS uses too many aliases/symlinks), I was able to conclude that in order for all apps to be found, you'd have to include `/System/Applications/` and `/System/Applications/Utilities`. 

I also made the function a little simpler to understand by replacing the two `cut` commands with the `basename` command inside the `find`'s  `-exec` parameter.

Here is a screenshot showing the differences:
![Screenshot 2020-08-29 at 17 46 56](https://user-images.githubusercontent.com/27065646/91641017-01e82480-ea22-11ea-87c7-8dae4afdc943.png)


