### PR TITLE
Update `dots` function to match new `shallow-backup` config format

### DIFF
--- a/.config/zsh/.zfunctions
+++ b/.config/zsh/.zfunctions
@@ -65,7 +65,7 @@ function pdiff() {
 
 # Grab dotfiles list from shallow-backup config and throw it in a fzf selector for editing
 function dots() {
-	cat ~/.config/shallow-backup.conf | jq '.dotfiles' | jq -r '.[]' | fzf --bind "enter:execute(nvim ~/{})"
+	cat ~/.config/shallow-backup.conf | jq '.dotfiles' | jq 'keys' | jq -r '.[]' | fzf --bind "enter:execute(nvim ~/{})"
 }
 
 # Source most config files.


### PR DESCRIPTION
Someone (the world may never know who) updated [shallow-backup](https://github.com/alichtman/shallow-backup) to make the config serve its purpose better. However, this `dots` function was never updated to reflect the changes of that config file.

Here's a 12 character fix to that :)